### PR TITLE
feat: add rangefunc support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,3 +13,5 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: go test -race -v ./...
+        env:
+          GOEXPERIMENT: rangefunc

--- a/example_test.go
+++ b/example_test.go
@@ -59,6 +59,25 @@ func ExampleReader_Event() {
 	// </root>
 }
 
+func ExampleReader_Events() {
+	xmlData := `<root><element>Value</element></root>`
+	reader := strings.NewReader(xmlData)
+
+	r := gosax.NewReader(reader)
+	for e, err := range r.Events {
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(string(e.Bytes))
+	}
+	// Output:
+	// <root>
+	// <element>
+	// Value
+	// </element>
+	// </root>
+}
+
 func ExampleNewReaderBuf() {
 	xmlData := `<root><element>Value</element></root>`
 	reader := strings.NewReader(xmlData)

--- a/range.go
+++ b/range.go
@@ -1,0 +1,17 @@
+//go:build (go1.22 && goexperiment.rangefunc) || go1.23
+
+package gosax
+
+// Events is a range function over all events, implementing [iter.Seq2].
+// It yields each event in order (except [EventEOF]) and an error, if any is encountered during reading.
+func (r *Reader) Events(yield func(Event, error) bool) {
+	for {
+		event, err := r.Event()
+		if event.Type() == EventEOF {
+			return
+		}
+		if !yield(event, err) {
+			return
+		}
+	}
+}


### PR DESCRIPTION
This makes use of the upcoming "rangefunc" support[0] to make the API slightly more ergonomic.

Naming is of course up for debate :innocent: 

[0] https://go.dev/wiki/RangefuncExperiment