### PR TITLE
Unescape StartElement attribute values to match encoding/xml

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -49,9 +49,13 @@ func StartElement(b []byte) (xml.StartElement, error) {
 		if err != nil {
 			return xml.StartElement{}, err
 		}
+		value, err := Unescape(attr.Value[1 : len(attr.Value)-1])
+		if err != nil {
+			return xml.StartElement{}, err
+		}
 		e.Attr = append(e.Attr, xml.Attr{
 			Name:  xmlName(attr.Key),
-			Value: string(attr.Value[1 : len(attr.Value)-1]),
+			Value: string(value),
 		})
 	}
 	return e, nil

--- a/example_test.go
+++ b/example_test.go
@@ -116,7 +116,7 @@ func ExampleReader_Reset() {
 }
 
 func ExampleToken() {
-	xmlData := `<root><element>Value</element></root>`
+	xmlData := `<root><element foo="&lt;bar&gt;" bar="qux">Value</element></root>`
 	reader := strings.NewReader(xmlData)
 
 	r := gosax.NewReader(reader)
@@ -135,6 +135,9 @@ func ExampleToken() {
 		switch t := t.(type) {
 		case xml.StartElement:
 			fmt.Println("StartElement", t.Name.Local)
+			for _, attr := range t.Attr {
+				fmt.Println("Attr", attr.Name.Local, attr.Value)
+			}
 		case xml.EndElement:
 			fmt.Println("EndElement", t.Name.Local)
 		case xml.CharData:
@@ -144,6 +147,8 @@ func ExampleToken() {
 	// Output:
 	// StartElement root
 	// StartElement element
+	// Attr foo <bar>
+	// Attr bar qux
 	// CharData Value
 	// EndElement element
 	// EndElement root


### PR DESCRIPTION
Although we don't actually use the standard library compatibility layer, I've noticed that when `encoding/xml` produces a `StartElement` token, the attribute values have their XML entities unescaped. For compatibility with the standard library, gosax should do the same.

[Here](https://play.golang.com/p/vIufrOEWGI1) is a Go Playground program demonstrating how `encoding/xml` works. It produces the following output, which now matches gosax's `ExampleToken` test:

```
StartElement root
StartElement element
Attr foo <bar>
Attr baz qux
CharData Value
EndElement element
EndElement root
```