### PR TITLE
fix multi line token parsing

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -49,8 +49,8 @@ func StartElement(b []byte) (xml.StartElement, error) {
 		if err != nil {
 			return xml.StartElement{}, err
 		}
-		if attr.Key == nil && attr.Value == nil {
-			continue
+		if len(attr.Key) == 0 {
+			break
 		}
 		value, err := Unescape(attr.Value[1 : len(attr.Value)-1])
 		if err != nil {

--- a/compat.go
+++ b/compat.go
@@ -49,6 +49,9 @@ func StartElement(b []byte) (xml.StartElement, error) {
 		if err != nil {
 			return xml.StartElement{}, err
 		}
+		if attr.Key == nil && attr.Value == nil {
+			continue
+		}
 		value, err := Unescape(attr.Value[1 : len(attr.Value)-1])
 		if err != nil {
 			return xml.StartElement{}, err

--- a/example_test.go
+++ b/example_test.go
@@ -199,7 +199,8 @@ func ExampleUnescape() {
 }
 
 func ExampleStartElement() {
-	xmlData := `<root><element foo="bar"
+	xmlData := `<root><element
+	foo="bar"
 	>
 	</element></root>`
 	reader := strings.NewReader(xmlData)

--- a/example_test.go
+++ b/example_test.go
@@ -197,3 +197,42 @@ func ExampleUnescape() {
 	// Output:
 	// "Line1\nLine2\nLine3\nLine4\nLine5\n"
 }
+
+func ExampleStartElement() {
+	xmlData := `<root><element foo="bar"
+	>
+	</element></root>`
+	reader := strings.NewReader(xmlData)
+
+	r := gosax.NewReader(reader)
+	for {
+		e, err := r.Event()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if e.Type() == gosax.EventEOF {
+			break
+		}
+		t, err := gosax.Token(e)
+		if err != nil {
+			log.Fatal(err)
+		}
+		switch t := t.(type) {
+		case xml.StartElement:
+			fmt.Println("StartElement", t.Name.Local)
+			for _, attr := range t.Attr {
+				fmt.Println("Attr", attr.Name.Local, attr.Value)
+			}
+		case xml.EndElement:
+			fmt.Println("EndElement", t.Name.Local)
+		case xml.CharData:
+			continue
+		}
+	}
+	// Output:
+	// StartElement root
+	// StartElement element
+	// Attr foo bar
+	// EndElement element
+	// EndElement root
+}


### PR DESCRIPTION
If the token contains whitespace/new line at the end, `NextAttribute` returns empty but no error. `StartElement` method calls `Unescape` method calling a substring without checking if `Value` was populated, leading to panic.

Example with golang's [parser](https://play.golang.com/p/XDDbX-63lsz)

