### PR TITLE
fix: Token.CharData should check underlying event type

### DIFF
--- a/xmlb/xmlb.go
+++ b/xmlb/xmlb.go
@@ -236,7 +236,7 @@ func (t Token) EndElement() xml.EndElement {
 }
 
 func (t Token) CharData() (xml.CharData, error) {
-	switch t.Type() {
+	switch gosax.Event(t).Type() {
 	case gosax.EventText:
 		return gosax.CharData(t.Bytes)
 	case gosax.EventCData:


### PR DESCRIPTION
Checking the type of the token compiles and partially works because both event types and token types share a type and gosax.EventText == xmllb.CharData.

Fixes #15